### PR TITLE
Fix bug in extra_args iteration.

### DIFF
--- a/src/aw_watcher_ask/cli.py
+++ b/src/aw_watcher_ask/cli.py
@@ -42,7 +42,7 @@ def _parse_extra_args(
 
             # if it is, remove it from un parsed args and split the option name
             # and an optional value (if format `--name=value` was used)
-            option_name, *option_values = extra_args.pop(ix).split("=", 1)
+            option_name, *option_values = extra_args[ix].split("=", 1)
             option_name = option_name.lstrip("-")
 
             if not option_values:
@@ -55,7 +55,7 @@ def _parse_extra_args(
                         break
                     else:
                         # is a value; remove it from unparsed args and store it
-                        option_values.append(extra_args.pop(ix))
+                        option_values.append(extra_args[ix])
 
             # have any value been found?
             if len(option_values) == 0:


### PR DESCRIPTION
In the current implementation, the extra_args list is modified in-place, so when the iteration over it continues, throws an IndexError here:
```
  File "[...]python3.9/site-packages/aw_watcher_ask/cli.py", line 41, in _parse_extra_args
    if extra_args[ix].startswith("-"):
IndexError: list index out of range
```
It looks like there is no need to actually remove the parsed arguments, so the changes to fix are minimal.  Happy to revise if I'm missing something.